### PR TITLE
Repository: update to use WordPress own repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Tags:** nodeinfo, fediverse, ostatus, diaspora, activitypub  
 **Requires at least:** 4.9  
 **Tested up to:** 6.1  
-**Stable tag:** 1.0.7  
+**Stable tag:** 1.0.8
 **Requires PHP:** 5.6  
 **License:** MIT  
 **License URI:** https://opensource.org/licenses/MIT  
@@ -23,6 +23,10 @@ This plugin provides a barebone JSON file with basic "node"-informations. The fi
 ## Changelog ##
 
 Project and support maintained on github at [pfefferle/wordpress-nodeinfo](https://github.com/pfefferle/wordpress-nodeinfo).
+
+### 1.0.8 ###
+
+* Fix link to WordPress repository.
 
 ### 1.0.7 ###
 

--- a/includes/class-nodeinfo.php
+++ b/includes/class-nodeinfo.php
@@ -54,7 +54,7 @@ class Nodeinfo {
 		);
 
 		if ( '2.1' === $this->version ) {
-			$software['repository'] = 'https://github.com/pfefferle/wordpress-nodeinfo';
+			$software['repository'] = 'https://github.com/wordpress/wordpress';
 		}
 
 		$this->software = apply_filters(

--- a/nodeinfo.php
+++ b/nodeinfo.php
@@ -3,7 +3,7 @@
  * Plugin Name: NodeInfo
  * Plugin URI: https://github.com/pfefferle/wordpress-nodeinfo/
  * Description: NodeInfo is an effort to create a standardized way of exposing metadata about a server running one of the distributed social networks.
- * Version: 1.0.7
+ * Version: 1.0.8
  * Author: Matthias Pfefferle
  * Author URI: https://notiz.blog/
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://notiz.blog/donate/
 Tags: nodeinfo, fediverse, ostatus, diaspora, activitypub
 Requires at least: 4.9
 Tested up to: 6.1
-Stable tag: 1.0.7
+Stable tag: 1.0.8
 Requires PHP: 5.6
 License: MIT
 License URI: https://opensource.org/licenses/MIT
@@ -23,6 +23,10 @@ This plugin provides a barebone JSON file with basic "node"-informations. The fi
 == Changelog ==
 
 Project and support maintained on github at [pfefferle/wordpress-nodeinfo](https://github.com/pfefferle/wordpress-nodeinfo).
+
+= 1.0.8 =
+
+* Fix link to WordPress repository.
 
 = 1.0.7 =
 


### PR DESCRIPTION
I was looking at your plugin, and was surprised to see the repository for the plugin listed for the repository key. Since this object lists info about the WordPress software, wouldn't it make more sense to use the WordPress repository there?

I may be missing something obvious though, so correct me if I'm wrong :)

<img width="628" alt="Screenshot 2023-01-06 at 15 28 50" src="https://user-images.githubusercontent.com/426388/211033042-1b0eef95-a623-4f17-9bbd-565dc426e5b9.png">
